### PR TITLE
Fixed [Issue #12] [Issue #16]

### DIFF
--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
@@ -280,10 +280,11 @@ public class UrlDetector {
         //unread the ":" so that the domain reader can process it
         _reader.goBack();
         
+        // Check buffer length before clearing it; set length to 0 if buffer is empty
         if (_buffer.length() > 0) {
-        	_buffer.delete(_buffer.length() - 1, _buffer.length());
+          _buffer.delete(_buffer.length() - 1, _buffer.length());
         } else {
-        	length = 0;
+          length = 0;
         }
 
         int backtrackOnFail = _reader.getPosition() - _buffer.length() + length;
@@ -293,6 +294,8 @@ public class UrlDetector {
           readEnd(ReadEndState.InvalidUrl);
         }
         length = 0;
+      } else {
+    	length = 0;
       }
     } else if (readScheme() && _buffer.length() > 0) {
       _hasScheme = true;


### PR DESCRIPTION
--[Issue #12] Fixed StringIndexOutOfBoundsException when given 'http://user:pass@host.com host.com' as input string--

Updated url-detector.processColon to set length to 0 when readUserPass(length) is true.

All unit tests passed after this update.

--[Issue #16] Fixed StringIndexOutOfBoundsException when input string contains the substring "//:@."--

Updated conditional statements in url-detector.processColon() to clear the buffer if it has contents when readUserPass fails, and to set length to 0 otherwise.

This resolved Issue #16 regarding a StringIndexOutOfBoundsException being thrown when provided the input string "://VIVE MARINE LE PEN//:@.". 

All unit tests still pass after this update. 