### PR TITLE
Added support for dots in the local part of an e-mail address.

### DIFF
--- a/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
@@ -102,7 +102,16 @@ public class DomainNameReader {
     /**
      * Finished reading, next step should be to read the query string.
      */
-    ReadQueryString
+    ReadQueryString,
+    /**
+     * Encountered an '@' while trying to read a domain name.
+     * We were possibly trying to read a domain name because we found a dot. But a dot is a common character
+     * in an e-mail address as well. If this case is not accounted for, things like first.last@domain.com will be
+     * detected as
+     * http://first.last
+     * http://domain.com
+     */
+    ReadUserPass
   }
 
   /**
@@ -332,6 +341,9 @@ public class DomainNameReader {
       } else if (curr == '#') {
         //continue by reading the fragment
         return checkDomainNameValid(ReaderNextState.ReadFragment, curr);
+      } else if (curr == '@') {
+        _buffer.append(curr);
+        return ReaderNextState.ReadUserPass;
       } else if (CharUtils.isDot(curr)
           || (curr == '%' && _reader.canReadChars(2) && _reader.peek(2).equalsIgnoreCase(HEX_ENCODED_DOT))) {
         //if the current character is a dot or a urlEncodedDot

--- a/url-detector/src/test/java/com/linkedin/urls/TestUrl.java
+++ b/url-detector/src/test/java/com/linkedin/urls/TestUrl.java
@@ -28,7 +28,9 @@ public class TestUrl {
         {"@www.google.com", "www.google.com", "/", "", ""},
         {"lalal:@www.gogo.com", "www.gogo.com", "/", "lalal", ""},
         {"nono:boo@[::1]", "[::1]", "/", "nono", "boo"},
-        {"nono:boo@yahoo.com/@1234", "yahoo.com", "/@1234", "nono", "boo"}
+        {"nono:boo@yahoo.com/@1234", "yahoo.com", "/@1234", "nono", "boo"},
+        {"fname.lname@blah.com", "blah.com", "/", "fname.lname", ""},
+        {"fname.middle.lname@blah.com", "blah.com", "/", "fname.middle.lname", ""}
     };
   }
 


### PR DESCRIPTION
This commit addresses issue #13 

Previously, if URL-Detector encountered something like...
`first.last@domain.com`

...it would detect two separate URLs:
`http://first.last`
`http://domain.com`

I believe the desired behavior is for one URL to be detected, with `getHost()` returning "domain.com" and `getUsername()` returning "first.last"


