### PR TITLE
Fixing null pointer exception when url doesn't have scheme

### DIFF
--- a/url-detector/src/main/java/com/linkedin/urls/Url.java
+++ b/url-detector/src/main/java/com/linkedin/urls/Url.java
@@ -114,7 +114,8 @@ public class Url {
     }
 
     url.append(getHost());
-    if (getPort() > 0 && getPort() != SCHEME_PORT_MAP.get(getScheme())) {
+    Integer schemePort = SCHEME_PORT_MAP.get(getScheme());
+    if (getPort() > 0 && (schemePort != null) && (getPort() != schemePort)) {
       url.append(":");
       url.append(getPort());
     }


### PR DESCRIPTION
When a url's scheme is empty, "SCHEME_PORT_MAP.get(getScheme());" returns null. Comparing a null Integer with a primitive integer causes a null pointer exception. This pull requests attempts to solve this null pointer exception.