### PR TITLE
While detecting Username and password in url we were not breaking the…

### DIFF
--- a/url-detector/pom.xml
+++ b/url-detector/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.linkedin.urls</groupId>
   <artifactId>url-detector</artifactId>
-  <version>0.2.1-alpha</version>
+  <version>0.2.2-alpha</version>
   <packaging>jar</packaging>
 
   <name>com.linkedin.urls:url-detector</name>

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
@@ -491,7 +491,7 @@ public class UrlDetector {
         //everything is still ok, just remember that we found a dot or '[' in case we might need to backtrack
         _buffer.append(curr);
         rollback = true;
-      } else if (curr == '#' || curr == ' ' || curr == '/'
+      } else if (curr == '#' || curr == ' ' || curr == '/' || curr ==':'
           || checkMatchingCharacter(curr) != CharacterMatch.CharacterNotMatched) {
         //one of these characters indicates we are invalid state and should just return.
         rollback = true;

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -643,6 +643,17 @@ public class TestUriDetection {
     String validUrl = tmp.substring(0, tmp.length() - 1) + zoneIndex + ']';
     runTest(validUrl, UrlDetectorOptions.Default, validUrl);
   }
+  @Test
+  public void testNegativeArraySizeException() {
+    String rawtext = "How ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\\n\\nCome ";
+    List<Url> urls = null;
+    try {
+      UrlDetector detector = new UrlDetector(rawtext, UrlDetectorOptions.Default);
+      urls = detector.detect();
+    } catch (NegativeArraySizeException e ) {
+      Assert.fail(e.getMessage());
+    }
+  }
 
   @Test
   public void testBacktrackInvalidUsernamePassword() {

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -643,6 +643,12 @@ public class TestUriDetection {
     String validUrl = tmp.substring(0, tmp.length() - 1) + zoneIndex + ']';
     runTest(validUrl, UrlDetectorOptions.Default, validUrl);
   }
+
+  @Test
+  public void testColonEmbededurl() {
+   runTest("::::::::::::::::::::::http://username:password@gmail.com:::::::::::::::",
+    UrlDetectorOptions.Default, "http://username:password@gmail.com");
+  }
   @Test
   public void testNegativeArraySizeException() {
     String rawtext = "How ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::\\n\\nCome ";


### PR DESCRIPTION
… iteration if we find the :

This means that if there was a long substring of : then we will iterate till the end of the : string
and then restart the same iteration for the next :.
This fix breaks the usename and password detection when it encounters the next : thus breaking the look early
and backtracking less.